### PR TITLE
fix: webserver-logs skip when container is down

### DIFF
--- a/.github/workflows/pull-request-check.yml
+++ b/.github/workflows/pull-request-check.yml
@@ -167,4 +167,8 @@ jobs:
       - name: Webserver logs
         if: always()
         run: |
-          docker-compose -f docker-compose.ghactions.yml logs webserver
+          if docker compose -f docker-compose.ghactions.yml ps | grep webserver; then
+            docker compose -f docker-compose.ghactions.yml logs webserver
+          else
+            echo "docker container webserver is not running, skipping webserver logs."
+          fi


### PR DESCRIPTION
don't show logs if the container is down. 